### PR TITLE
Silence MSAN warning when running protoc

### DIFF
--- a/src/google/protobuf/compiler/importer.cc
+++ b/src/google/protobuf/compiler/importer.cc
@@ -490,7 +490,7 @@ io::ZeroCopyInputStream* DiskSourceTree::OpenVirtualFile(
 
 io::ZeroCopyInputStream* DiskSourceTree::OpenDiskFile(
     const std::string& filename) {
-  struct stat sb;
+  struct stat sb = {0};
   int ret = 0;
   do {
     ret = stat(filename.c_str(), &sb);


### PR DESCRIPTION
(port of https://github.com/ClickHouse/protobuf/pull/4 to this repo)

When building CH with msan flags you get warnings from protoc (as it's built with the flags):

```
cd /mnt/ch/ClickHouse/build_msan/contrib/arrow-cmake && /mnt/ch/ClickHouse/build_msan/contrib/protobuf-cmake/protoc -I /mnt/ch/ClickHouse/contrib/orc/c++/../proto --cpp_out="/mnt/ch/ClickHouse/build_msan/contrib/arrow-cmake" /mnt/ch/ClickHouse/contrib/orc/c++/../proto/orc_proto.proto
==500166==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0xdd383e in google::protobuf::compiler::DiskSourceTree::OpenDiskFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) build_msan/./contrib/protobuf/src/google/protobuf/compiler/importer.cc:504:7
    #1 0xdd1eb2 in google::protobuf::compiler::DiskSourceTree::DiskFileToVirtualFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) build_msan/./contrib/protobuf/src/google/protobuf/compiler/importer.cc:431:51
    #2 0x540619 in google::protobuf::compiler::CommandLineInterface::MakeProtoProtoPathRelative(google::protobuf::compiler::DiskSourceTree*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*, google::protobuf::DescriptorDatabase*) build_msan/./contrib/protobuf/src/google/protobuf/compiler/command_line_interface.cc:1362:24
    #3 0x5314fb in google::protobuf::compiler::CommandLineInterface::MakeInputsBeProtoPathRelative(google::protobuf::compiler::DiskSourceTree*, google::protobuf::DescriptorDatabase*) build_msan/./contrib/protobuf/src/google/protobuf/compiler/command_line_interface.cc:1415:10
    #4 0x5314fb in google::protobuf::compiler::CommandLineInterface::InitializeDiskSourceTree(google::protobuf::compiler::DiskSourceTree*, google::protobuf::DescriptorDatabase*) build_msan/./contrib/protobuf/src/google/protobuf/compiler/command_line_interface.cc:1168:8
    #5 0x52541f in google::protobuf::compiler::CommandLineInterface::Run(int, char const* const*) build_msan/./contrib/protobuf/src/google/protobuf/compiler/command_line_interface.cc:1026:10
    #6 0x50f5d6 in google::protobuf::compiler::ProtobufMain(int, char**) build_msan/./contrib/protobuf/src/google/protobuf/compiler/main.cc:104:14
    #7 0x50fe58 in main build_msan/./contrib/protobuf/src/google/protobuf/compiler/main.cc:112:10
    #8 0x7f817143db24 in __libc_start_main (/usr/lib/libc.so.6+0x27b24)
    #9 0x48904d in _start (/mnt/ch/ClickHouse/build_msan/contrib/protobuf-cmake/protoc+0x48904d)

  Uninitialized value was created by an allocation of 'sb' in the stack frame of function '_ZN6google8protobuf8compiler14DiskSourceTree12OpenDiskFileERKNSt3__112basic_stringIcNS3_11char_traitsIcEENS3_9allocatorIcEEEE'
    #0 0xdd3320 in google::protobuf::compiler::DiskSourceTree::OpenDiskFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&) build_msan/./contrib/protobuf/src/google/protobuf/compiler/importer.cc:492

SUMMARY: MemorySanitizer: use-of-uninitialized-value build_msan/./contrib/protobuf/src/google/protobuf/compiler/importer.cc:504:7 in google::protobuf::compiler::DiskSourceTree::OpenDiskFile(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)
Exiting
```