### PR TITLE
Resolve the error generated by cross-compiled mcmodel=extreme or loon…

### DIFF
--- a/src/google/protobuf/port_def.inc
+++ b/src/google/protobuf/port_def.inc
@@ -290,7 +290,8 @@ static_assert(PROTOBUF_ABSL_MIN(20230125, 3),
 #endif
 #if ABSL_HAVE_CPP_ATTRIBUTE(clang::musttail) && !defined(__arm__) &&  \
     !defined(_ARCH_PPC) && !defined(__wasm__) &&                      \
-    !(defined(_MSC_VER) && defined(_M_IX86)) && !defined(__i386__)
+    !(defined(_MSC_VER) && defined(_M_IX86)) && !defined(__i386__) &&  \
+    !defined(__loongarch__)
 // Compilation fails on ARM32: b/195943306
 // Compilation fails on powerpc64le: b/187985113
 // Compilation fails on X86 Windows:


### PR DESCRIPTION
…garch64 on x86_x64

Enable ClickHouse to cross-compile for loongarch64 on x86_x64, so that it can run on loongarch64 So far, only basic functions have been tested (on real hardware: 3B5000, 3C5000, 3C6000), The ClickHouse server is running and functioning normally, and the client is working, The basic function test is effective, affecting only loongarch64-linux-gnu Resolve the error generated by cross-compiled mcmodel=extreme Specific operation
build/bin/clang++  --target=loongarch64-linux-gnu -mcmodel=extreme  -o  {BUILD_PATH}/google-protobuf/src/google/protobuf/generated_message_tctable_lite.cc.o -c {CLICKHOUSE_SRC_PATH}/google-protobuf/src/google/protobuf/generated_message_tctable_lite.cc Error message
fatal error: error in backend: failed to perform tail call elimination on a call site marked musttail
1.      <eof> parser at end of file
2.      Code generation
3.      Running pass 'Function Pass Manager' on module '{CLICKHOUSE_SRC_PATH}/contrib/google-protobuf/src/google/protobuf/generated_message_tctable_lite.cc'.
4.      Running pass 'LoongArch DAG->DAG Pattern Instruction Selection' on function '@_ZN6google8protobuf8internal8TcParser9MiniParseEPNS0_11MessageLiteEPKcPNS1_12ParseContextENS1_11TcFieldDataEPKNS1_16TcParseTableBaseEm'
 #0 0x0000000001f919d7 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) (build/bin/clang+++0x1f919d7)
...............
...............